### PR TITLE
Add keyboard mapping and default triangle wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and waveforms while visualizing the sound.
 
 - **Intonation presets:** Equal temperament, Just Intonation (5‑limit), Pythagorean,
   and nearest harmonic tuning.
-- **Waveforms:** Sine, triangle, sawtooth, and square.
+- **Waveforms:** Sine, triangle (default), sawtooth, and square.
 - **ADSR envelope:** Adjustable attack, decay, sustain, and release times.
 - **MIDI support:** Connect a MIDI controller for input.
 - **Visual feedback:** Animated line tiles respond to the audio envelope.
@@ -18,6 +18,13 @@ and waveforms while visualizing the sound.
 1. Open `index.html` in a modern web browser.
 2. Click **Tap to Begin** to enable audio.
 3. Play notes using your computer keyboard or a connected MIDI device.
+
+   Keyboard mapping covers C2–C5:
+
+   - `1`–`=` → C2–B2
+   - `Q`–`]` → C3–B3
+   - `A`–`\` → C4–B4
+   - `Z` → C5
 
 The controls panel lets you change intonation, waveform, volume, and ADSR
 parameters. Current tuning metadata appears below the sliders when relevant.

--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
       </select>
       <label for="wave">Wave</label>
       <select id="wave">
-        <option value="sine" selected>Sine</option>
-        <option value="triangle">Triangle</option>
+        <option value="sine">Sine</option>
+        <option value="triangle" selected>Triangle</option>
         <option value="sawtooth">Saw</option>
         <option value="square">Square</option>
       </select>

--- a/sketch.js
+++ b/sketch.js
@@ -310,6 +310,40 @@ function noteOff(m) {
   }
 }
 
+// ===== Computer Keyboard =====
+const KEYBOARD_ROWS = [
+  ['Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit5', 'Digit6', 'Digit7', 'Digit8', 'Digit9', 'Digit0', 'Minus', 'Equal'], // C2-B2
+  ['KeyQ', 'KeyW', 'KeyE', 'KeyR', 'KeyT', 'KeyY', 'KeyU', 'KeyI', 'KeyO', 'KeyP', 'BracketLeft', 'BracketRight'], // C3-B3
+  ['KeyA', 'KeyS', 'KeyD', 'KeyF', 'KeyG', 'KeyH', 'KeyJ', 'KeyK', 'KeyL', 'Semicolon', 'Quote', 'Backslash'], // C4-B4
+  ['KeyZ'], // C5
+];
+const KEY_TO_MIDI = {};
+let midiBase = 36; // MIDI note for C2
+for (const row of KEYBOARD_ROWS) {
+  for (const code of row) {
+    KEY_TO_MIDI[code] = midiBase++;
+  }
+}
+
+window.addEventListener('keydown', (e) => {
+  if (e.repeat) return;
+  if (['INPUT', 'SELECT', 'TEXTAREA'].includes(e.target.tagName)) return;
+  const m = KEY_TO_MIDI[e.code];
+  if (m !== undefined) {
+    e.preventDefault();
+    noteOn(m);
+  }
+});
+
+window.addEventListener('keyup', (e) => {
+  if (['INPUT', 'SELECT', 'TEXTAREA'].includes(e.target.tagName)) return;
+  const m = KEY_TO_MIDI[e.code];
+  if (m !== undefined) {
+    e.preventDefault();
+    noteOff(m);
+  }
+});
+
 function retuneActiveVoices() {
   for (const m of activeNotes) {
     const v = voices.get(m);


### PR DESCRIPTION
## Summary
- Make triangle oscillator the default waveform
- Allow computer keyboard input across C2–C5
- Document keyboard layout and default waveform

## Testing
- `node --check sketch.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af4a8ec5008320ab893214eab3591e